### PR TITLE
Create I_CategoryRepository interface

### DIFF
--- a/ecommers/src/main/java/com/example/ecommers/repository/I_CategoryRepository.java
+++ b/ecommers/src/main/java/com/example/ecommers/repository/I_CategoryRepository.java
@@ -1,0 +1,16 @@
+package com.example.ecommers.repository;
+
+import com.example.ecommers.model.CategoryEntity;
+import com.example.ecommers.model.ProductoEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Repositorio para gestionar operaciones relacionadas con la entidad de categoría ({@link CategoryEntity}).
+ * Extiende {@link JpaRepository} proporcionando operaciones básicas de CRUD.
+ */
+@Repository
+public interface I_CategoryRepository extends JpaRepository<CategoryEntity, Long> {
+}


### PR DESCRIPTION
La consulta de "traer productos de una categoría" habría que hacerla en el repositorio de producto, ya que la relación entre producto y categoría se guarda en la tabla de producto y no de categoría, dejo la imagen.
![image](https://github.com/Javier20001/SofttekEcommerce/assets/83076950/37f90af2-766a-49a1-94e3-56bd3d53a2a7)
